### PR TITLE
Update GitHub workflows for Google Cloud authentication

### DIFF
--- a/.github/workflows/dbt_hourly.yml
+++ b/.github/workflows/dbt_hourly.yml
@@ -38,12 +38,12 @@ jobs:
       - name: Authenticate to Google Cloud
         uses: google-github-actions/auth@v1
         with:
-          credentials_json: ${{ secrets.GCP_SA_KEY }}
+          credentials_json: ${{ secrets.GOOGLE_APPLICATION_CREDENTIALS }}
 
       - name: Run dbt
         working-directory: ./dbt
         run: |
-          echo '${{ secrets.GCP_SA_KEY }}' > ../keyfile.json
+          echo '${{ secrets.GOOGLE_APPLICATION_CREDENTIALS }}' > ../keyfile.json
           export GOOGLE_APPLICATION_CREDENTIALS="../keyfile.json"
 
           dbt debug --no-version-check

--- a/.github/workflows/dbt_run.yml
+++ b/.github/workflows/dbt_run.yml
@@ -40,12 +40,12 @@ jobs:
       - name: Authenticate to Google Cloud
         uses: google-github-actions/auth@v1
         with:
-          credentials_json: ${{ secrets.GCP_SA_KEY }}
+          credentials_json: ${{ secrets.GOOGLE_APPLICATION_CREDENTIALS }}
 
       - name: Run dbt
         working-directory: ./dbt
         run: |
-          echo '${{ secrets.GCP_SA_KEY }}' > ../keyfile.json
+          echo '${{ secrets.GOOGLE_APPLICATION_CREDENTIALS }}' > ../keyfile.json
 
           export GOOGLE_APPLICATION_CREDENTIALS="../keyfile.json"
 
@@ -62,7 +62,7 @@ jobs:
         if: success()
         working-directory: ./dbt
         run: |
-          echo '${{ secrets.GCP_SA_KEY }}' > ../keyfile.json
+          echo '${{ secrets.GOOGLE_APPLICATION_CREDENTIALS }}' > ../keyfile.json
           export GOOGLE_APPLICATION_CREDENTIALS="../keyfile.json"
           dbt docs generate
           rm -f ../keyfile.json

--- a/.github/workflows/deploy_flows.yaml
+++ b/.github/workflows/deploy_flows.yaml
@@ -18,6 +18,7 @@ on:
   workflow_dispatch:
 
 env:
+  GOOGLE_APPLICATION_CREDENTIALS: ${{ secrets.GOOGLE_APPLICATION_CREDENTIALS }}
   GCP_PROJECT_ID: ${{ secrets.GCP_PROJECT_ID }}
   GAR_LOCATION: ${{ secrets.GAR_LOCATION || 'us-central1' }}
   GAR_REPOSITORY: ${{ secrets.GAR_REPOSITORY || 'prefect-images' }}
@@ -43,7 +44,7 @@ jobs:
       - name: Authenticate to Google Cloud
         uses: google-github-actions/auth@v2
         with:
-          credentials_json: ${{ secrets.GOOGLE_CREDENTIALS_DOCKER }}
+          credentials_json: ${{ secrets.GOOGLE_APPLICATION_CREDENTIALS }}
 
       - name: Set up Google Cloud SDK
         uses: google-github-actions/setup-gcloud@v2
@@ -66,9 +67,9 @@ jobs:
         with:
           context: .
           push: true
-          target: runtime # Target the runtime stage
-          cache-from: type=registry,ref=${{ env.FULL_IMAGE_NAME }}:cache
-          cache-to: type=registry,ref=${{ env.FULL_IMAGE_NAME }}:cache,mode=max
+          target: runtime
+          cache-from: type=registry,ref=${{ env.GAR_LOCATION }}-docker.pkg.dev/${{ env.GCP_PROJECT_ID }}/${{ env.GAR_REPOSITORY }}/${{ env.IMAGE_NAME }}-${{ env.ENVIRONMENT }}:cache
+          cache-to: type=registry,ref=${{ env.GAR_LOCATION }}-docker.pkg.dev/${{ env.GCP_PROJECT_ID }}/${{ env.GAR_REPOSITORY }}/${{ env.IMAGE_NAME }}-${{ env.ENVIRONMENT }}:cache,mode=max
           tags: |
             ${{ env.FULL_IMAGE_NAME }}
             ${{ env.GAR_LOCATION }}-docker.pkg.dev/${{ env.GCP_PROJECT_ID }}/${{ env.GAR_REPOSITORY }}/${{ env.IMAGE_NAME }}-${{ env.ENVIRONMENT }}:latest


### PR DESCRIPTION
Switch authentication method in GitHub workflows to use `GOOGLE_APPLICATION_CREDENTIALS` for improved security and consistency.